### PR TITLE
pylocales: handle executables produced by PyInstaller.

### DIFF
--- a/src/pylocales/locales.py
+++ b/src/pylocales/locales.py
@@ -52,6 +52,9 @@ if __path__ is None:
         __path__ = os.path.abspath(os.path.dirname(sys.executable))
     elif frozen == 'macosx_app':
         __path__ = os.path.abspath(os.environ['RESOURCEPATH'])
+    elif frozen is True:
+        # Handle executables produced by PyInstaller.
+        __path__ = sys._MEIPASS
     else:
         __path__ = os.path.abspath(os.path.realpath(os.path.dirname(__file__)))
     


### PR DESCRIPTION
In applications "frozen" with PyInstaller, `getattr(sys, 'frozen', None)` returns `True`, so the check in pylocales/locales.py should probably be extended to include the check below.