### PR TITLE
GTK 4 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,14 +5,15 @@ Python GTK Spellcheck
 
 Python GTK Spellcheck is a simple but quite powerful spellchecking library for GTK written
 in pure Python. It's spellchecking component is based on Enchant_ and it supports both GTK
-bindings (PyGObject_, PyGTK_) as well as Python 3 and 2.
+3 and 4 via PyGObject_ with Python 3.
 
 
 Features
 --------
 - **spellchecking** based on Enchant_ for `GtkTextViews`
 - support for word, line and multiple line **ignore regular expressions**
-- PyGObject_ and PyGtk_ (automatic detection) as well as Python 3 and 2 compatible
+- GTK 3 or 4
+- PyGObject_ with Python 3
 - localized names of the available languages based on ISO-Codes_
 - support for custom ignore tags and hot swap of `GtkTextBuffers`
 - enable and disable of spellchecking with preferences memory
@@ -26,7 +27,6 @@ Features
 
 .. _Enchant: http://www.abisource.com/projects/enchant/
 .. _PyGObject: https://live.gnome.org/PyGObject/
-.. _PyGTK: http://www.pygtk.org/
 .. _ISO-Codes: http://pkg-isocodes.alioth.debian.org/
 
 

--- a/examples/collapsed_gtk3.py
+++ b/examples/collapsed_gtk3.py
@@ -27,18 +27,18 @@ import locale
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk as gtk
+from gi.repository import Gtk
 
 from gtkspellcheck import SpellChecker
 
 if __name__ == "__main__":
 
     def quit(*args):
-        gtk.main_quit()
+        Gtk.main_quit()
 
-    window = gtk.Window.new(gtk.WindowType.TOPLEVEL)
+    window = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
     window.set_title("PyGtkSpellCheck Example")
-    view = gtk.TextView.new()
+    view = Gtk.TextView.new()
 
     spellchecker = SpellChecker(view, locale.getdefaultlocale()[0])
 
@@ -49,4 +49,4 @@ if __name__ == "__main__":
     window.add(view)
     window.show_all()
     window.connect("delete-event", quit)
-    gtk.main()
+    Gtk.main()

--- a/examples/collapsed_gtk3.py
+++ b/examples/collapsed_gtk3.py
@@ -24,6 +24,9 @@ sys.path.append(join(dirname(__file__), "../src/"))
 
 import locale
 
+import gi
+
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk as gtk
 
 from gtkspellcheck import SpellChecker
@@ -37,7 +40,7 @@ if __name__ == "__main__":
     window.set_title("PyGtkSpellCheck Example")
     view = gtk.TextView.new()
 
-    spellchecker = SpellChecker(view, locale.getdefaultlocale()[0], collapse=False)
+    spellchecker = SpellChecker(view, locale.getdefaultlocale()[0])
 
     for code, name in spellchecker.languages:
         print("code: %5s, language: %s" % (code, name))

--- a/examples/collapsed_gtk4.py
+++ b/examples/collapsed_gtk4.py
@@ -24,26 +24,35 @@ sys.path.append(join(dirname(__file__), "../src/"))
 
 import locale
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
 
 from gtkspellcheck import SpellChecker
 
+
+class TestApp(Gtk.Application):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.connect("activate", self.activate)
+
+    def activate(self, _app: Gtk.Application):
+        window = Gtk.Window()
+        window.set_title("PyGtkSpellCheck GTK Example")
+        view = Gtk.TextView()
+
+        self.spellchecker = SpellChecker(view, locale.getdefaultlocale()[0])
+        for code, name in self.spellchecker.languages:
+            print("code: %5s, language: %s" % (code, name))
+
+        self.view = view
+        window.set_child(view)
+        window.set_default_size(600, 400)
+        self.add_window(window)
+        window.present()
+
+
 if __name__ == "__main__":
-
-    def quit(*args):
-        gtk.main_quit()
-
-    window = gtk.Window(gtk.WINDOW_TOPLEVEL)
-    window.set_title("PyGtkSpellCheck Example")
-    view = gtk.TextView()
-
-    spellchecker = SpellChecker(view, locale.getdefaultlocale()[0], collapse=False)
-
-    for code, name in spellchecker.languages:
-        print("code: %5s, language: %s" % (code, name))
-
-    window.set_default_size(600, 400)
-    window.add(view)
-    window.show_all()
-    window.connect("delete-event", quit)
-    gtk.main()
+    app = TestApp()
+    app.run()

--- a/examples/expanded_gtk3.py
+++ b/examples/expanded_gtk3.py
@@ -24,6 +24,9 @@ sys.path.append(join(dirname(__file__), "../src/"))
 
 import locale
 
+import gi
+
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk as gtk
 
 from gtkspellcheck import SpellChecker
@@ -37,7 +40,7 @@ if __name__ == "__main__":
     window.set_title("PyGtkSpellCheck Example")
     view = gtk.TextView.new()
 
-    spellchecker = SpellChecker(view, locale.getdefaultlocale()[0])
+    spellchecker = SpellChecker(view, locale.getdefaultlocale()[0], collapse=False)
 
     for code, name in spellchecker.languages:
         print("code: %5s, language: %s" % (code, name))

--- a/examples/expanded_gtk3.py
+++ b/examples/expanded_gtk3.py
@@ -27,18 +27,18 @@ import locale
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk as gtk
+from gi.repository import Gtk
 
 from gtkspellcheck import SpellChecker
 
 if __name__ == "__main__":
 
     def quit(*args):
-        gtk.main_quit()
+        Gtk.main_quit()
 
-    window = gtk.Window.new(gtk.WindowType.TOPLEVEL)
+    window = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
     window.set_title("PyGtkSpellCheck Example")
-    view = gtk.TextView.new()
+    view = Gtk.TextView.new()
 
     spellchecker = SpellChecker(view, locale.getdefaultlocale()[0], collapse=False)
 
@@ -49,4 +49,4 @@ if __name__ == "__main__":
     window.add(view)
     window.show_all()
     window.connect("delete-event", quit)
-    gtk.main()
+    Gtk.main()

--- a/examples/expanded_gtk4.py
+++ b/examples/expanded_gtk4.py
@@ -24,26 +24,37 @@ sys.path.append(join(dirname(__file__), "../src/"))
 
 import locale
 
-import gtk
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
 
 from gtkspellcheck import SpellChecker
 
+
+class TestApp(Gtk.Application):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.connect("activate", self.activate)
+
+    def activate(self, _app: Gtk.Application):
+        window = Gtk.Window()
+        window.set_title("PyGtkSpellCheck GTK Example")
+        view = Gtk.TextView()
+
+        self.spellchecker = SpellChecker(
+            view, locale.getdefaultlocale()[0], collapse=False
+        )
+        for code, name in self.spellchecker.languages:
+            print("code: %5s, language: %s" % (code, name))
+
+        self.view = view
+        window.set_child(view)
+        window.set_default_size(600, 400)
+        self.add_window(window)
+        window.present()
+
+
 if __name__ == "__main__":
-
-    def quit(*args):
-        gtk.main_quit()
-
-    window = gtk.Window(gtk.WINDOW_TOPLEVEL)
-    window.set_title("PyGtkSpellCheck Example")
-    view = gtk.TextView()
-
-    spellchecker = SpellChecker(view, locale.getdefaultlocale()[0])
-
-    for code, name in spellchecker.languages:
-        print("code: %5s, language: %s" % (code, name))
-
-    window.set_default_size(600, 400)
-    window.add(view)
-    window.show_all()
-    window.connect("delete-event", quit)
-    gtk.main()
+    app = TestApp()
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pygtkspellcheck"
-version = "4.0.6"
+version = "5.0.0"
 description = "A simple but quite powerful spellchecking library for GTK written in pure Python."
 authors = [
     "Maximilian Köhl <mail@koehlma.de>"

--- a/setup.py
+++ b/setup.py
@@ -113,9 +113,6 @@ if len(sys.argv) > 1 and sys.argv[1] == "bdist_wininst":
     print("windows bdist_wininst include iso message files")
 
 py_modules = []
-gtkspell = os.getenv("GTKSPELL")
-if sys.version_info.major == 2 and gtkspell is not None and gtkspell.lower() == "true":
-    py_modules.append("gtkspell")
 
 setup(
     name=variables["name"],

--- a/src/gtkspellcheck/__init__.py
+++ b/src/gtkspellcheck/__init__.py
@@ -55,7 +55,6 @@ __metadata__ = {
 from gtkspellcheck.spellcheck import (
     SpellChecker,
     NoDictionariesFound,
-    NoGtkBindingFound,
 )
 
-__all__ = ["SpellChecker", "NoDictionariesFound", "NoGtkBindingFound"]
+__all__ = ["SpellChecker", "NoDictionariesFound"]

--- a/src/gtkspellcheck/spellcheck.py
+++ b/src/gtkspellcheck/spellcheck.py
@@ -585,7 +585,7 @@ class SpellChecker(GObject.Object):
                         suggestion, f"spelling.replace-word('{escaped}')"
                     )
                 menu.append(item)
-        add_to_dict_menu_label = _('Add "{}" to Dictionary').format(word)
+        add_to_dict_menu_label = _("Add to Dictionary")
         word_escaped = word.replace("'", "\\'")
         if _IS_GTK3:
             menu.append(Gtk.SeparatorMenuItem.new())

--- a/src/gtkspellcheck/spellcheck.py
+++ b/src/gtkspellcheck/spellcheck.py
@@ -18,9 +18,8 @@
 
 """
 A simple but quite powerful spellchecking library written in pure Python for Gtk
-based on Enchant. It supports PyGObject as well as PyGtk for Python 2 and 3 with
-automatic switching and binding detection. For automatic translation of the user
-interface it can use Gedit’s translation files.
+based on Enchant. It supports both GTK 3 and 4 via PyGObject with Python 3. For
+automatic translation of the user interface it can use Gedit’s translation files.
 """
 
 import enchant

--- a/src/gtkspellcheck/spellcheck.py
+++ b/src/gtkspellcheck/spellcheck.py
@@ -37,12 +37,12 @@ from gi.repository import Gio, GLib, GObject
 
 # find any loaded gtk binding
 if "gi.repository.Gtk" in sys.modules:
-    gtk = sys.modules["gi.repository.Gtk"]
+    Gtk = sys.modules["gi.repository.Gtk"]
 else:
     import gi
 
     gi.require_version("Gtk", "3.0")
-    from gi.repository import Gtk as gtk  # noqa: N813
+    from gi.repository import Gtk  # noqa: N813
 
 # public objects
 __all__ = ["SpellChecker", "NoDictionariesFound"]
@@ -177,7 +177,7 @@ class SpellChecker(GObject.Object):
         super().__init__()
         self._view = view
         self.collapse = collapse
-        if gtk.MAJOR_VERSION < 4:
+        if Gtk.MAJOR_VERSION < 4:
             self._view.connect(
                 "populate-popup", lambda entry, menu: self._extend_menu(menu)
             )
@@ -228,7 +228,7 @@ class SpellChecker(GObject.Object):
         }
 
         self._languages_menu = None
-        if gtk.MAJOR_VERSION > 3:
+        if Gtk.MAJOR_VERSION > 3:
             extra_menu = self._view.get_extra_menu()
             if extra_menu is None:
                 extra_menu = Gio.Menu()
@@ -236,7 +236,7 @@ class SpellChecker(GObject.Object):
             self._spelling_menu = Gio.Menu()
             extra_menu.append_section(None, self._spelling_menu)
 
-            controller = gtk.GestureClick()
+            controller = Gtk.GestureClick()
             controller.set_button(0)
             controller.connect("pressed", self.__on_click_pressed)
             self._view.add_controller(controller)
@@ -280,7 +280,7 @@ class SpellChecker(GObject.Object):
         have associated a new GtkTextBuffer with the GtkTextView call this
         method.
         """
-        self._misspelled = gtk.TextTag.new("{}-misspelled".format(self._prefix))
+        self._misspelled = Gtk.TextTag.new("{}-misspelled".format(self._prefix))
         self._misspelled.set_property("underline", 4)
         self._buffer = self._view.get_buffer()
         self._buffer.connect("insert-text", self._before_text_insert)
@@ -316,7 +316,7 @@ class SpellChecker(GObject.Object):
         self._table.foreach(tag_added, None)
         self.no_spell_check = self._table.lookup("no-spell-check")
         if not self.no_spell_check:
-            self.no_spell_check = gtk.TextTag.new("no-spell-check")
+            self.no_spell_check = Gtk.TextTag.new("no-spell-check")
             self._table.add(self.no_spell_check)
         self.recheck()
 
@@ -505,7 +505,7 @@ class SpellChecker(GObject.Object):
         self._view.insert_action_group("spelling", action_group)
 
     def _get_languages_menu(self):
-        if gtk.MAJOR_VERSION > 3:
+        if Gtk.MAJOR_VERSION > 3:
             if self._languages_menu is None:
                 self._languages_menu = self._build_languages_menu()
             return self._languages_menu
@@ -513,36 +513,36 @@ class SpellChecker(GObject.Object):
             return self._build_languages_menu()
 
     def _build_languages_menu(self):
-        if gtk.MAJOR_VERSION > 3:
+        if Gtk.MAJOR_VERSION > 3:
             menu = Gio.Menu.new()
         else:
 
             def _set_language(item, code):
                 self.language = code
 
-            menu = gtk.Menu.new()
+            menu = Gtk.Menu.new()
             group = []
             connect = []
 
         for code, name in self.languages:
-            if gtk.MAJOR_VERSION > 3:
+            if Gtk.MAJOR_VERSION > 3:
                 item = Gio.MenuItem.new(name, None)
                 item.set_action_and_target_value(
                     "spelling.language", GLib.Variant.new_string(code)
                 )
                 menu.append_item(item)
             else:
-                item = gtk.RadioMenuItem.new_with_label(group, name)
+                item = Gtk.RadioMenuItem.new_with_label(group, name)
                 group.append(item)
                 if code == self.language:
                     item.set_active(True)
                 connect.append((item, code))
                 menu.append(item)
-        if gtk.MAJOR_VERSION < 4:
+        if Gtk.MAJOR_VERSION < 4:
             for item, code in connect:
                 item.connect("activate", _set_language, code)
 
-        if gtk.MAJOR_VERSION > 3:
+        if Gtk.MAJOR_VERSION > 3:
             return Gio.MenuItem.new_submenu(_("Languages"), menu)
         return menu
 
@@ -550,11 +550,11 @@ class SpellChecker(GObject.Object):
         menu = []
         suggestions = self._dictionary.suggest(word)
         if not suggestions:
-            if gtk.MAJOR_VERSION < 4:
-                item = gtk.MenuItem.new()
-                label = gtk.Label.new("")
+            if Gtk.MAJOR_VERSION < 4:
+                item = Gtk.MenuItem.new()
+                label = Gtk.Label.new("")
                 try:
-                    label.set_halign(gtk.Align.LEFT)
+                    label.set_halign(Gtk.Align.LEFT)
                 except AttributeError:
                     label.set_alignment(0.0, 0.5)
                 label.set_markup("<i>{text}</i>".format(text=_("(no suggestions)")))
@@ -562,17 +562,17 @@ class SpellChecker(GObject.Object):
                 menu.append(item)
         else:
             for suggestion in suggestions:
-                if gtk.MAJOR_VERSION > 3:
+                if Gtk.MAJOR_VERSION > 3:
                     escaped = suggestion.replace("'", "\\'")
                     item = Gio.MenuItem.new(
                         suggestion, f"spelling.replace-word('{escaped}')"
                     )
                 else:
-                    item = gtk.MenuItem.new()
-                    label = gtk.Label.new("")
+                    item = Gtk.MenuItem.new()
+                    label = Gtk.Label.new("")
                     label.set_markup("<b>{text}</b>".format(text=suggestion))
                     try:
-                        label.set_halign(gtk.Align.LEFT)
+                        label.set_halign(Gtk.Align.LEFT)
                     except AttributeError:
                         label.set_alignment(0.0, 0.5)
                     item.add(label)
@@ -582,40 +582,40 @@ class SpellChecker(GObject.Object):
                 menu.append(item)
         add_to_dict_menu_label = _('Add "{}" to Dictionary').format(word)
         word_escaped = word.replace("'", "\\'")
-        if gtk.MAJOR_VERSION > 3:
+        if Gtk.MAJOR_VERSION > 3:
             item = Gio.MenuItem.new(
                 add_to_dict_menu_label, f"spelling.add-to-dictionary('{word_escaped}')"
             )
         else:
-            menu.append(gtk.SeparatorMenuItem.new())
-            item = gtk.MenuItem.new_with_label(add_to_dict_menu_label)
+            menu.append(Gtk.SeparatorMenuItem.new())
+            item = Gtk.MenuItem.new_with_label(add_to_dict_menu_label)
             item.connect("activate", lambda *args: self.add_to_dictionary(word))
         menu.append(item)
         ignore_menu_label = _("Ignore All")
-        if gtk.MAJOR_VERSION > 3:
+        if Gtk.MAJOR_VERSION > 3:
             item = Gio.MenuItem.new(
                 ignore_menu_label, f"spelling.ignore-all('{word_escaped}')"
             )
         else:
-            item = gtk.MenuItem.new_with_label(ignore_menu_label)
+            item = Gtk.MenuItem.new_with_label(ignore_menu_label)
             item.connect("activate", lambda *args: self.ignore_all(word))
         menu.append(item)
         return menu
 
     def _extend_menu(self, menu):
-        if gtk.MAJOR_VERSION > 3:
+        if Gtk.MAJOR_VERSION > 3:
             menu.remove_all()
 
         if not self._enabled:
             return
 
-        if gtk.MAJOR_VERSION > 3:
+        if Gtk.MAJOR_VERSION > 3:
             menu.append_item(self._get_languages_menu())
         else:
-            separator = gtk.SeparatorMenuItem.new()
+            separator = Gtk.SeparatorMenuItem.new()
             separator.show()
             menu.prepend(separator)
-            languages = gtk.MenuItem.new_with_label(_("Languages"))
+            languages = Gtk.MenuItem.new_with_label(_("Languages"))
             languages.set_submenu(self._get_languages_menu())
             languages.show_all()
             menu.prepend(languages)
@@ -627,19 +627,19 @@ class SpellChecker(GObject.Object):
                 items = self._suggestion_menu(word)
                 if self.collapse:
                     menu_label = _("Suggestions")
-                    if gtk.MAJOR_VERSION > 3:
+                    if Gtk.MAJOR_VERSION > 3:
                         suggestions = Gio.MenuItem.new(menu_label, None)
                         submenu = Gio.Menu.new()
                     else:
-                        suggestions = gtk.MenuItem.new_with_label(menu_label)
-                        submenu = gtk.Menu.new()
+                        suggestions = Gtk.MenuItem.new_with_label(menu_label)
+                        submenu = Gtk.Menu.new()
                     for item in items:
-                        if gtk.MAJOR_VERSION > 3:
+                        if Gtk.MAJOR_VERSION > 3:
                             submenu.append_item(item)
                         else:
                             submenu.append(item)
                     suggestions.set_submenu(submenu)
-                    if gtk.MAJOR_VERSION > 3:
+                    if Gtk.MAJOR_VERSION > 3:
                         menu.prepend_item(suggestions)
                     else:
                         suggestions.show_all()
@@ -647,7 +647,7 @@ class SpellChecker(GObject.Object):
                 else:
                     items.reverse()
                     for item in items:
-                        if gtk.MAJOR_VERSION > 3:
+                        if Gtk.MAJOR_VERSION > 3:
                             menu.prepend_item(item)
                         else:
                             menu.prepend(item)
@@ -730,7 +730,7 @@ class SpellChecker(GObject.Object):
             if self._regexes[SpellChecker.FILTER_WORD].match(word):
                 return
         if len(self._filters[SpellChecker.FILTER_LINE]):
-            if gtk.MAJOR_VERSION > 3:
+            if Gtk.MAJOR_VERSION > 3:
                 _success, line_start = self._buffer.get_iter_at_line(start.get_line())
             else:
                 line_start = self._buffer.get_iter_at_line(start.get_line())
@@ -739,7 +739,7 @@ class SpellChecker(GObject.Object):
             line = self._buffer.get_text(line_start, line_end, False)
             for match in self._regexes[SpellChecker.FILTER_LINE].finditer(line):
                 if match.start() <= start.get_line_offset() <= match.end():
-                    if gtk.MAJOR_VERSION > 3:
+                    if Gtk.MAJOR_VERSION > 3:
                         _success, start = self._buffer.get_iter_at_line_offset(
                             start.get_line(), match.start()
                         )

--- a/src/gtkspellcheck/spellcheck.py
+++ b/src/gtkspellcheck/spellcheck.py
@@ -238,10 +238,10 @@ class SpellChecker(GObject.Object):
 
             controller = Gtk.GestureClick()
             controller.set_button(0)
-            controller.connect("pressed", self.__on_click_pressed)
+            controller.connect("pressed", self._gtk4_on_textview_click)
             self._view.add_controller(controller)
 
-            self._setup_actions()
+            self._gtk4_setup_actions()
 
         self._enabled = True
         self.buffer_initialize()
@@ -477,7 +477,7 @@ class SpellChecker(GObject.Object):
                 break
             word_start = word_end.copy()
 
-    def _setup_actions(self) -> None:
+    def _gtk4_setup_actions(self) -> None:
         action_group = Gio.SimpleActionGroup.new()
 
         action = Gio.SimpleAction.new("ignore-all", GLib.VariantType("s"))
@@ -673,14 +673,7 @@ class SpellChecker(GObject.Object):
             iter = iter[1]
         self._marks["click"].move(iter)
 
-    def __on_click_pressed(self, click, n_press, x, y) -> None:
-        # TODO this type of approach would be better (and is eg. what gnome-text-editor uses)
-        #      but get_current_sequence always returns null
-        # sequence = click.get_current_sequence()
-        # event = click.get_last_event(sequence)
-        # if n_press != 1 or not Gdk.Event.triggers_context_menu(event):
-        #     return
-
+    def _gtk4_on_textview_click(self, click, n_press, x, y) -> None:
         if n_press != 1 or click.get_current_button() != 3:
             return
 

--- a/src/gtkspellcheck/spellcheck.py
+++ b/src/gtkspellcheck/spellcheck.py
@@ -28,12 +28,24 @@ import gettext
 import logging
 import re
 import sys
+from collections import UserList
 
 from pylocales import code_to_name as _code_to_name
 from pylocales import LanguageNotFound, CountryNotFound
 
+from gi.repository import Gio, GLib, GObject
+
+# find any loaded gtk binding
+if "gi.repository.Gtk" in sys.modules:
+    gtk = sys.modules["gi.repository.Gtk"]
+else:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    from gi.repository import Gtk as gtk  # noqa: N813
+
 # public objects
-__all__ = ["SpellChecker", "NoDictionariesFound", "NoGtkBindingFound"]
+__all__ = ["SpellChecker", "NoDictionariesFound"]
 
 # logger
 logger = logging.getLogger(__name__)
@@ -45,46 +57,6 @@ class NoDictionariesFound(Exception):
     spellchecking could not work in any way.
     """
 
-
-class NoGtkBindingFound(Exception):
-    """
-    Could not find any loaded Gtk binding.
-    """
-
-
-if sys.version_info.major == 3:
-    _py3k = True
-else:
-    _py3k = False
-
-if _py3k:
-    # there is only the gi binding for Python 3
-    from gi.repository import Gtk as gtk  # noqa: N813
-
-    _pygobject = True
-else:
-    # find any loaded gtk binding
-    if "gi.repository.Gtk" in sys.modules:
-        gtk = sys.modules["gi.repository.Gtk"]
-        _pygobject = True
-    elif "gtk" in sys.modules:
-        gtk = sys.modules["gtk"]
-        _pygobject = False
-    else:
-        raise NoGtkBindingFound("could not find any loaded Gtk binding")
-
-# select base list class
-try:
-    from collections import UserList
-
-    _list = UserList
-except ImportError:
-    _list = list
-
-
-# select base string
-if _py3k:
-    basestring = str
 
 # map between Gedit's translation and PyGtkSpellcheck's
 _GEDIT_MAP = {
@@ -115,7 +87,7 @@ def code_to_name(code, separator="_"):
         return "{} ({})".format(_("Unknown"), code)
 
 
-class SpellChecker(object):
+class SpellChecker(GObject.Object):
     """
     Main spellchecking class, everything important happens here.
 
@@ -152,12 +124,9 @@ class SpellChecker(object):
         FILTER_TEXT: [],
     }
 
-    class _LanguageList(_list):
+    class _LanguageList(UserList):
         def __init__(self, *args, **kwargs):
-            if sys.version_info.major == 3:
-                super().__init__(*args, **kwargs)
-            else:
-                _list.__init__(self, *args, **kwargs)
+            super().__init__(*args, **kwargs)
             self.mapping = dict(self)
 
         @classmethod
@@ -205,13 +174,15 @@ class SpellChecker(object):
     def __init__(
         self, view, language="en", prefix="gtkspellchecker", collapse=True, params=None
     ):
+        super().__init__()
         self._view = view
         self.collapse = collapse
-        self._view.connect(
-            "populate-popup", lambda entry, menu: self._extend_menu(menu)
-        )
-        self._view.connect("popup-menu", self._click_move_popup)
-        self._view.connect("button-press-event", self._click_move_button)
+        if gtk.MAJOR_VERSION < 4:
+            self._view.connect(
+                "populate-popup", lambda entry, menu: self._extend_menu(menu)
+            )
+            self._view.connect("popup-menu", self._click_move_popup)
+            self._view.connect("button-press-event", self._click_move_button)
         self._prefix = prefix
         self._broker = enchant.Broker()
         if params is not None:
@@ -255,10 +226,27 @@ class SpellChecker(object):
                 "|".join(self._filters[SpellChecker.FILTER_TEXT]), re.MULTILINE
             ),
         }
+
+        self._languages_menu = None
+        if gtk.MAJOR_VERSION > 3:
+            extra_menu = self._view.get_extra_menu()
+            if extra_menu is None:
+                extra_menu = Gio.Menu()
+                self._view.set_extra_menu(extra_menu)
+            self._spelling_menu = Gio.Menu()
+            extra_menu.append_section(None, self._spelling_menu)
+
+            controller = gtk.GestureClick()
+            controller.set_button(0)
+            controller.connect("pressed", self.__on_click_pressed)
+            self._view.add_controller(controller)
+
+            self._setup_actions()
+
         self._enabled = True
         self.buffer_initialize()
 
-    @property
+    @GObject.Property(type=str, default="")
     def language(self):
         """
         The language used for spellchecking.
@@ -272,7 +260,7 @@ class SpellChecker(object):
             self._dictionary = self._broker.request_dict(language)
             self.recheck()
 
-    @property
+    @GObject.Property(type=bool, default=False)
     def enabled(self):
         """
         Enable or disable spellchecking.
@@ -292,10 +280,7 @@ class SpellChecker(object):
         have associated a new GtkTextBuffer with the GtkTextView call this
         method.
         """
-        if _pygobject:
-            self._misspelled = gtk.TextTag.new("{}-misspelled".format(self._prefix))
-        else:
-            self._misspelled = gtk.TextTag("{}-misspelled".format(self._prefix))
+        self._misspelled = gtk.TextTag.new("{}-misspelled".format(self._prefix))
         self._misspelled.set_property("underline", 4)
         self._buffer = self._view.get_buffer()
         self._buffer.connect("insert-text", self._before_text_insert)
@@ -331,10 +316,7 @@ class SpellChecker(object):
         self._table.foreach(tag_added, None)
         self.no_spell_check = self._table.lookup("no-spell-check")
         if not self.no_spell_check:
-            if _pygobject:
-                self.no_spell_check = gtk.TextTag.new("no-spell-check")
-            else:
-                self.no_spell_check = gtk.TextTag("no-spell-check")
+            self.no_spell_check = gtk.TextTag.new("no-spell-check")
             self._table.add(self.no_spell_check)
         self.recheck()
 
@@ -418,7 +400,7 @@ class SpellChecker(object):
 
         :param tag: Tag object or tag name.
         """
-        if isinstance(tag, basestring):
+        if isinstance(tag, str):
             tag = self._table.lookup(tag)
         self.ignored_tags.append(tag)
 
@@ -429,7 +411,7 @@ class SpellChecker(object):
 
         :param tag: Tag object or tag name.
         """
-        if isinstance(tag, basestring):
+        if isinstance(tag, str):
             tag = self._table.lookup(tag)
         self.ignored_tags.remove(tag)
 
@@ -495,121 +477,181 @@ class SpellChecker(object):
                 break
             word_start = word_end.copy()
 
-    def _languages_menu(self):
-        def _set_language(item, code):
-            self.language = code
+    def _setup_actions(self) -> None:
+        action_group = Gio.SimpleActionGroup.new()
 
-        if _pygobject:
+        action = Gio.SimpleAction.new("ignore-all", GLib.VariantType("s"))
+        action.connect(
+            "activate", lambda _action, word: self.ignore_all(word.get_string())
+        )
+        action_group.add_action(action)
+
+        action = Gio.SimpleAction.new("add-to-dictionary", GLib.VariantType("s"))
+        action.connect(
+            "activate", lambda _action, word: self.add_to_dictionary(word.get_string())
+        )
+        action_group.add_action(action)
+
+        action = Gio.SimpleAction.new("replace-word", GLib.VariantType("s"))
+        action.connect(
+            "activate",
+            lambda _action, suggestion: self._replace_word(suggestion.get_string()),
+        )
+        action_group.add_action(action)
+
+        language = Gio.PropertyAction.new("language", self, "language")
+        action_group.add_action(language)
+
+        self._view.insert_action_group("spelling", action_group)
+
+    def _get_languages_menu(self):
+        if gtk.MAJOR_VERSION > 3:
+            if self._languages_menu is None:
+                self._languages_menu = self._build_languages_menu()
+            return self._languages_menu
+        else:
+            return self._build_languages_menu()
+
+    def _build_languages_menu(self):
+        if gtk.MAJOR_VERSION > 3:
+            menu = Gio.Menu.new()
+        else:
+
+            def _set_language(item, code):
+                self.language = code
+
             menu = gtk.Menu.new()
             group = []
-        else:
-            menu = gtk.Menu()
-            group = gtk.RadioMenuItem()
-        connect = []
+            connect = []
+
         for code, name in self.languages:
-            if _pygobject:
+            if gtk.MAJOR_VERSION > 3:
+                item = Gio.MenuItem.new(name, None)
+                item.set_action_and_target_value(
+                    "spelling.language", GLib.Variant.new_string(code)
+                )
+                menu.append_item(item)
+            else:
                 item = gtk.RadioMenuItem.new_with_label(group, name)
                 group.append(item)
-            else:
-                item = gtk.RadioMenuItem(group, name)
-            if code == self.language:
-                item.set_active(True)
-            connect.append((item, code))
-            menu.append(item)
-        for item, code in connect:
-            item.connect("activate", _set_language, code)
+                if code == self.language:
+                    item.set_active(True)
+                connect.append((item, code))
+                menu.append(item)
+        if gtk.MAJOR_VERSION < 4:
+            for item, code in connect:
+                item.connect("activate", _set_language, code)
+
+        if gtk.MAJOR_VERSION > 3:
+            return Gio.MenuItem.new_submenu(_("Languages"), menu)
         return menu
 
     def _suggestion_menu(self, word):
         menu = []
         suggestions = self._dictionary.suggest(word)
         if not suggestions:
-            if _pygobject:
+            if gtk.MAJOR_VERSION < 4:
                 item = gtk.MenuItem.new()
                 label = gtk.Label.new("")
-            else:
-                item = gtk.MenuItem()
-                label = gtk.Label()
-            try:
-                label.set_halign(gtk.Align.LEFT)
-            except AttributeError:
-                label.set_alignment(0.0, 0.5)
-            label.set_markup("<i>{text}</i>".format(text=_("(no suggestions)")))
-            item.add(label)
-            menu.append(item)
-        else:
-            for suggestion in suggestions:
-                if _pygobject:
-                    item = gtk.MenuItem.new()
-                    label = gtk.Label.new("")
-                else:
-                    item = gtk.MenuItem()
-                    label = gtk.Label()
-                label.set_markup("<b>{text}</b>".format(text=suggestion))
                 try:
                     label.set_halign(gtk.Align.LEFT)
                 except AttributeError:
                     label.set_alignment(0.0, 0.5)
+                label.set_markup("<i>{text}</i>".format(text=_("(no suggestions)")))
                 item.add(label)
-                item.connect("activate", self._replace_word, word, suggestion)
                 menu.append(item)
-        if _pygobject:
+        else:
+            for suggestion in suggestions:
+                if gtk.MAJOR_VERSION > 3:
+                    escaped = suggestion.replace("'", "\\'")
+                    item = Gio.MenuItem.new(
+                        suggestion, f"spelling.replace-word('{escaped}')"
+                    )
+                else:
+                    item = gtk.MenuItem.new()
+                    label = gtk.Label.new("")
+                    label.set_markup("<b>{text}</b>".format(text=suggestion))
+                    try:
+                        label.set_halign(gtk.Align.LEFT)
+                    except AttributeError:
+                        label.set_alignment(0.0, 0.5)
+                    item.add(label)
+                    item.connect(
+                        "activate", lambda *args: self._replace_word(suggestion)
+                    )
+                menu.append(item)
+        add_to_dict_menu_label = _('Add "{}" to Dictionary').format(word)
+        word_escaped = word.replace("'", "\\'")
+        if gtk.MAJOR_VERSION > 3:
+            item = Gio.MenuItem.new(
+                add_to_dict_menu_label, f"spelling.add-to-dictionary('{word_escaped}')"
+            )
+        else:
             menu.append(gtk.SeparatorMenuItem.new())
-            item = gtk.MenuItem.new_with_label(_('Add "{}" to Dictionary').format(word))
-        else:
-            menu.append(gtk.SeparatorMenuItem())
-            item = gtk.MenuItem(_('Add "{}" to Dictionary').format(word))
-        item.connect("activate", lambda *args: self.add_to_dictionary(word))
+            item = gtk.MenuItem.new_with_label(add_to_dict_menu_label)
+            item.connect("activate", lambda *args: self.add_to_dictionary(word))
         menu.append(item)
-        if _pygobject:
-            item = gtk.MenuItem.new_with_label(_("Ignore All"))
+        ignore_menu_label = _("Ignore All")
+        if gtk.MAJOR_VERSION > 3:
+            item = Gio.MenuItem.new(
+                ignore_menu_label, f"spelling.ignore-all('{word_escaped}')"
+            )
         else:
-            item = gtk.MenuItem(_("Ignore All"))
-        item.connect("activate", lambda *args: self.ignore_all(word))
+            item = gtk.MenuItem.new_with_label(ignore_menu_label)
+            item.connect("activate", lambda *args: self.ignore_all(word))
         menu.append(item)
         return menu
 
     def _extend_menu(self, menu):
+        if gtk.MAJOR_VERSION > 3:
+            menu.remove_all()
+
         if not self._enabled:
             return
-        if _pygobject:
+
+        if gtk.MAJOR_VERSION > 3:
+            menu.append_item(self._get_languages_menu())
+        else:
             separator = gtk.SeparatorMenuItem.new()
-        else:
-            separator = gtk.SeparatorMenuItem()
-        separator.show()
-        menu.prepend(separator)
-        if _pygobject:
+            separator.show()
+            menu.prepend(separator)
             languages = gtk.MenuItem.new_with_label(_("Languages"))
-        else:
-            languages = gtk.MenuItem(_("Languages"))
-        languages.set_submenu(self._languages_menu())
-        languages.show_all()
-        menu.prepend(languages)
+            languages.set_submenu(self._get_languages_menu())
+            languages.show_all()
+            menu.prepend(languages)
+
         if self._marks["click"].inside_word:
             start, end = self._marks["click"].word
             if start.has_tag(self._misspelled):
-                if _py3k:
-                    word = self._buffer.get_text(start, end, False)
-                else:
-                    word = self._buffer.get_text(start, end, False).decode("utf-8")
+                word = self._buffer.get_text(start, end, False)
                 items = self._suggestion_menu(word)
                 if self.collapse:
-                    if _pygobject:
-                        suggestions = gtk.MenuItem.new_with_label(_("Suggestions"))
-                        submenu = gtk.Menu.new()
+                    menu_label = _("Suggestions")
+                    if gtk.MAJOR_VERSION > 3:
+                        suggestions = Gio.MenuItem.new(menu_label, None)
+                        submenu = Gio.Menu.new()
                     else:
-                        suggestions = gtk.MenuItem(_("Suggestions"))
-                        submenu = gtk.Menu()
+                        suggestions = gtk.MenuItem.new_with_label(menu_label)
+                        submenu = gtk.Menu.new()
                     for item in items:
-                        submenu.append(item)
+                        if gtk.MAJOR_VERSION > 3:
+                            submenu.append_item(item)
+                        else:
+                            submenu.append(item)
                     suggestions.set_submenu(submenu)
-                    suggestions.show_all()
-                    menu.prepend(suggestions)
+                    if gtk.MAJOR_VERSION > 3:
+                        menu.prepend_item(suggestions)
+                    else:
+                        suggestions.show_all()
+                        menu.prepend(suggestions)
                 else:
                     items.reverse()
                     for item in items:
-                        menu.prepend(item)
-                        menu.show_all()
+                        if gtk.MAJOR_VERSION > 3:
+                            menu.prepend_item(item)
+                        else:
+                            menu.prepend(item)
+                            menu.show_all()
 
     def _click_move_popup(self, *args):
         self._marks["click"].move(
@@ -619,14 +661,31 @@ class SpellChecker(object):
 
     def _click_move_button(self, widget, event):
         if event.button == 3:
-            if self._deferred_check:
-                self._check_deferred_range(True)
-            x, y = self._view.window_to_buffer_coords(2, int(event.x), int(event.y))
-            iter = self._view.get_iter_at_location(x, y)
-            if isinstance(iter, tuple):
-                iter = iter[1]
-            self._marks["click"].move(iter)
+            self._move_mark_for_input(event.x, event.y)
         return False
+
+    def _move_mark_for_input(self, input_x, input_y):
+        if self._deferred_check:
+            self._check_deferred_range(True)
+        x, y = self._view.window_to_buffer_coords(2, int(input_x), int(input_y))
+        iter = self._view.get_iter_at_location(x, y)
+        if isinstance(iter, tuple):
+            iter = iter[1]
+        self._marks["click"].move(iter)
+
+    def __on_click_pressed(self, click, n_press, x, y) -> None:
+        # TODO this type of approach would be better (and is eg. what gnome-text-editor uses)
+        #      but get_current_sequence always returns null
+        # sequence = click.get_current_sequence()
+        # event = click.get_last_event(sequence)
+        # if n_press != 1 or not Gdk.Event.triggers_context_menu(event):
+        #     return
+
+        if n_press != 1 or click.get_current_button() != 3:
+            return
+
+        self._move_mark_for_input(x, y)
+        self._extend_menu(self._spelling_menu)
 
     def _before_text_insert(self, textbuffer, location, text, length):
         self._marks["insert-start"].move(location)
@@ -643,8 +702,9 @@ class SpellChecker(object):
         if mark == self._buffer.get_insert() and self._deferred_check:
             self._check_deferred_range(False)
 
-    def _replace_word(self, item, old_word, new_word):
+    def _replace_word(self, new_word):
         start, end = self._marks["click"].word
+        old_word = start.get_text(end)
         offset = start.get_offset()
         self._buffer.begin_user_action()
         self._buffer.delete(start, end)
@@ -663,43 +723,41 @@ class SpellChecker(object):
         for tag in self.ignored_tags:
             if start.has_tag(tag):
                 return
-        if _py3k:
-            word = self._buffer.get_text(start, end, False).strip()
-        else:
-            word = self._buffer.get_text(start, end, False).decode("utf-8").strip()
+        word = self._buffer.get_text(start, end, False).strip()
         if not word:
             return
         if len(self._filters[SpellChecker.FILTER_WORD]):
             if self._regexes[SpellChecker.FILTER_WORD].match(word):
                 return
         if len(self._filters[SpellChecker.FILTER_LINE]):
-            line_start = self._buffer.get_iter_at_line(start.get_line())
+            if gtk.MAJOR_VERSION > 3:
+                _success, line_start = self._buffer.get_iter_at_line(start.get_line())
+            else:
+                line_start = self._buffer.get_iter_at_line(start.get_line())
             line_end = end.copy()
             line_end.forward_to_line_end()
-            if _py3k:
-                line = self._buffer.get_text(line_start, line_end, False)
-            else:
-                line = self._buffer.get_text(line_start, line_end, False).decode(
-                    "utf-8"
-                )
+            line = self._buffer.get_text(line_start, line_end, False)
             for match in self._regexes[SpellChecker.FILTER_LINE].finditer(line):
                 if match.start() <= start.get_line_offset() <= match.end():
-                    start = self._buffer.get_iter_at_line_offset(
-                        start.get_line(), match.start()
-                    )
-                    end = self._buffer.get_iter_at_line_offset(
-                        start.get_line(), match.end()
-                    )
+                    if gtk.MAJOR_VERSION > 3:
+                        _success, start = self._buffer.get_iter_at_line_offset(
+                            start.get_line(), match.start()
+                        )
+                        _success, end = self._buffer.get_iter_at_line_offset(
+                            start.get_line(), match.end()
+                        )
+                    else:
+                        start = self._buffer.get_iter_at_line_offset(
+                            start.get_line(), match.start()
+                        )
+                        end = self._buffer.get_iter_at_line_offset(
+                            start.get_line(), match.end()
+                        )
                     self._buffer.remove_tag(self._misspelled, start, end)
                     return
         if len(self._filters[SpellChecker.FILTER_TEXT]):
             text_start, text_end = self._buffer.get_bounds()
-            if _py3k:
-                text = self._buffer.get_text(text_start, text_end, False)
-            else:
-                text = self._buffer.get_text(text_start, text_end, False).decode(
-                    "utf-8"
-                )
+            text = self._buffer.get_text(text_start, text_end, False)
             for match in self._regexes[SpellChecker.FILTER_TEXT].finditer(text):
                 if match.start() <= start.get_offset() <= match.end():
                     start = self._buffer.get_iter_at_offset(match.start())


### PR DESCRIPTION
Hey Maximilian,

I've gotten around to massaging my GTK 4 changes in with some GTK 3 support for this first draft changeset.

As planned this drops Python 2 and GTK 2 support.

Mixed notes:
- GTK 4 menu changes necessitate building menus from the model as done in the PR
- I believe removed signals in GTK 4 result in the `GestureClick` usage to repopulate suggestions in the menu (and update the current word mark)
- I looked into using a menu model to populate the menu for GTK 3 but this didn't appear to be possible
- Initially I had a few separate methods for GTK 3 and 4 but have combined those to be more like what you had before for separating functionality for GTK 2/3 and Python 2/3. I'm not sure if it's more readable, but it's a starting point.
- In my initial quick changes branch I had some other changes that I've removed here: I'd changed menu item `Ignore All` to `Ignore` and `Add <word> to Dictionary` to `Add to Dictionary`. I still like this simpler wording (which follows the interaction set in one of the first GTK4 apps to have spell checking - Text Editor), but presumed you'd rather not change it.
- On that theme there are a couple of changes in place for GTK 4 though, up for discussion: the separator between the suggestions and following items isn't there, and the `"(no suggestions)"` menu item isn't added. The later is at least in part due to the fact that it's not possible to do italic formatting on in the menu with GTK 4, and again, copies what was in gnome-text-editor. All up for discussion.
- I looked at not inheriting from `GObject` but I believe that's necessary for the `PropertyAction`, which provides the language selection menu its state behaviour
- It should be possible to detect whether the `GestureClick` is occurring on a popup-generating button using `gdk_event_triggers_context_menu` but haven't yet been able to get a hold on the sequence or yet determine the root cause of why I can't (sorry, time lack). At the moment it's matching to button 3, which might be fine for now, but there's at least a TODO to remove. Perhaps you have some better GTK input handling debugging skills and might be able to solve this :slightly_smiling_face: 
- Removed Gtk module renaming as no longer needed
- `_replace_word` has been changed to build the old word from the mark instead of passing it in (which works better with the GTK 4 action-based interaction). Do you see any issue with this?
- I haven't looked at whether the property changes (or inheritance?) will impact Python 3 w/ GTK 3 API compatibility

Hopefully a reasonable starting point 😀