### PR TITLE
Add a simple mechanism to batch the rechecking of large buffers

### DIFF
--- a/src/gtkspellcheck/spellcheck.py
+++ b/src/gtkspellcheck/spellcheck.py
@@ -789,6 +789,8 @@ class SpellChecker(GObject.Object):
             self._buffer.apply_tag(self._misspelled, start, end)
 
     def _continue_batched_recheck(self, start_mark):
+        if start_mark.get_buffer() != self._buffer:
+            return
         start = self._buffer.get_iter_at_mark(start_mark)
         self._buffer.delete_mark(start_mark)
 

--- a/src/gtkspellcheck/spellcheck.py
+++ b/src/gtkspellcheck/spellcheck.py
@@ -789,11 +789,12 @@ class SpellChecker(GObject.Object):
             self._buffer.apply_tag(self._misspelled, start, end)
 
     def _continue_batched_recheck(self, start_mark):
+        start = self._buffer.get_iter_at_mark(start_mark)
+        self._buffer.delete_mark(start_mark)
+
         if not self._enabled:
             return
 
-        start = self._buffer.get_iter_at_mark(start_mark)
-        self._buffer.delete_mark(start_mark)
         end = start.copy()
         end.forward_chars(_BATCH_SIZE_CHARS)
         end.forward_word_end()

--- a/src/gtkspellcheck/spellcheck.py
+++ b/src/gtkspellcheck/spellcheck.py
@@ -350,7 +350,7 @@ class SpellChecker(GObject.Object):
             start_mark = self._buffer.create_mark(None, start)
             self._continue_batched_recheck(start_mark)
         else:
-            end = self.check_range(start, end, True)
+            self.check_range(start, end, True)
 
     def disable(self):
         """


### PR DESCRIPTION
Hey Maximilian,

As discussed here's the PR for the addition of some optional basic batching for rechecks to big buffers. This is particularly useful for less powerful devices, eg. the current generation of Linux smartphones.

Let me know :slightly_smiling_face: 