### PR TITLE
Fix integrating pasted text which has been tagged misspelled

### DIFF
--- a/src/gtkspellcheck/spellcheck.py
+++ b/src/gtkspellcheck/spellcheck.py
@@ -589,6 +589,8 @@ class SpellChecker(GObject.Object):
         )
         if not self._enabled:
             return
+        start = start.copy()
+        end = end.copy()
         if self._iter_worker.inside_word(end):
             self._iter_worker.forward_word_end(end)
         if self._iter_worker.inside_word(start) or self._iter_worker.ends_word(start):


### PR DESCRIPTION
Resolves issue where we were modifying the location iterator passed in from `GtkTextBuffer`'s `insert-text` signal, a [no no](https://docs.gtk.org/gtk4/signal.TextBuffer.insert-text.html).

Seems to not be passing flake8 on an unrelated issue, presumably a flake8 update?

Fixes #50.